### PR TITLE
キャッシュによるCIの高速化

### DIFF
--- a/.github/workflows/fo_testing_cache.txt
+++ b/.github/workflows/fo_testing_cache.txt
@@ -1,0 +1,1 @@
+I am matumoto.

--- a/.github/workflows/fo_testing_cache.txt
+++ b/.github/workflows/fo_testing_cache.txt
@@ -1,1 +1,0 @@
-I am matumoto.

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,9 @@ jobs:
       run: |
         npm ci
 
+    - name: Dump
+      echo steps.dot_npm_cache_id.outputs.cache-hit
+
     - name: Run ESLint
       run: |
         npm run eslint

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,6 @@ jobs:
         key: $${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install npm dependencies
-      if: steps.dot_npm_cache_id.outputs.cache-hit != 'true'
       run: |
         npm ci
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,9 +9,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache .npm
+      id: dot_npm_cache_id
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: $${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
     - name: Install npm dependencies
+      if: steps.dot_npm_chache_id.outputs.cache-hit == 'false'
       run: |
-        npm install
+        npm ci
 
     - name: Run ESLint
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
         key: $${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install npm dependencies
-      if: steps.dot_npm_chache_id.outputs.cache-hit == 'false'
+      if: steps.dot_npm_cache_id.outputs.cache-hit == 'false'
       run: |
         npm ci
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,12 +17,9 @@ jobs:
         key: $${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install npm dependencies
-      if: steps.dot_npm_cache_id.outputs.cache-hit == 'false'
+      if: steps.dot_npm_cache_id.outputs.cache-hit != 'true'
       run: |
         npm ci
-
-    - name: Dump
-      echo steps.dot_npm_cache_id.outputs.cache-hit
 
     - name: Run ESLint
       run: |


### PR DESCRIPTION
## Issue 番号
<!-- この Pull request に関連する Issue 番号 -->
<!-- example: - close #10 -->
- close #96 

## 変更内容
<!-- この Pull request の変更点 -->

- .npm に対してキャッシュを使用した
- npm ci に変更した

  - [参考](https://dev.classmethod.jp/articles/cicd-npm-ci-cache/)
    > npm ci でパッケージのインストールをした場合は node_modules ディレクトリは毎回新しく構築されるため、キャッシュしていても意味がありませんでした。
